### PR TITLE
Fix/stability improvements

### DIFF
--- a/components/Hoko/Ko-nodisponible.vue
+++ b/components/Hoko/Ko-nodisponible.vue
@@ -1,0 +1,18 @@
+<template>
+  <div class="flex min-h-96 flex-col items-center justify-center px-4 py-16">
+    <div class="text-center">
+      <h2 class="mb-4 text-2xl font-semibold text-gray-700">
+        Productos Hoko
+      </h2>
+      <p class="text-gray-500">
+        Esta funcionalidad no está disponible para este template.
+      </p>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'KoNoDisponibleHoko',
+}
+</script>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -85,6 +85,7 @@ export default {
   // Facebook Pixel module configuration
   facebook: { pixelId: '671820736795254', autoPageView: true },
   serverMiddleware: [
+    '~/server-middleware/block-bots.js',
     '~/server-middleware/cache-control.js',
     '~/server-middleware/redirect-wapi-stores.js',
   ],

--- a/pages/productosHoko/index.vue
+++ b/pages/productosHoko/index.vue
@@ -25,9 +25,15 @@ export default {
         9: 'K09ProductListHoko',
         10: 'KoNoDisponibleHoko',
         11: 'K11ProductListHoko',
+        12: 'KoNoDisponibleHoko',
         13: 'KoNoDisponibleHoko',
         14: 'KoNoDisponibleHoko',
+        15: 'KoNoDisponibleHoko',
+        16: 'KoNoDisponibleHoko',
+        17: 'KoNoDisponibleHoko',
+        99: 'KoNoDisponibleHoko',
       },
+      defaultComponent: 'KoNoDisponibleHoko',
     }
   },
   computed: {
@@ -46,12 +52,11 @@ export default {
     //   return this.$store.getters['products/filterProducts']
     // },
     indexTemplate() {
-      let productListComponent = ''
       // eslint-disable-next-line no-prototype-builtins
       if (this.componentMapping.hasOwnProperty(this.template)) {
-        productListComponent = this.componentMapping[parseInt(this.template)]
+        return this.componentMapping[parseInt(this.template)]
       }
-      return productListComponent
+      return this.defaultComponent
     },
     componentsProps() {
       return {

--- a/server-middleware/block-bots.js
+++ b/server-middleware/block-bots.js
@@ -1,0 +1,74 @@
+// server-middleware/block-bots.js
+// Bloquea rutas típicas de bots/scanners para evitar carga innecesaria en SSR
+
+const BLOCKED_PATHS = [
+  // WordPress
+  '/wp-login.php',
+  '/wp-admin',
+  '/wp-content',
+  '/wp-includes',
+  '/xmlrpc.php',
+  // Joomla
+  '/administrator',
+  // Drupal
+  '/sites/default/files',
+  '/node/',
+  // OpenCart / Magento
+  '/admin/controller',
+  '/index.php/admin',
+  // Common exploit paths
+  '/.env',
+  '/.git',
+  '/.svn',
+  '/config.php',
+  '/phpinfo.php',
+  '/phpmyadmin',
+  '/pma',
+  '/mysql',
+  '/backup',
+  '/db',
+  '/database',
+  '/sql',
+  '/dump',
+  // Otros paths problemáticos vistos en logs
+  '/cordClip',
+  '/cgi-bin',
+  '/scripts',
+  '/aws',
+  '/azure',
+  '/gcloud',
+]
+
+const BLOCKED_EXTENSIONS = [
+  '.php',
+  '.asp',
+  '.aspx',
+  '.jsp',
+  '.cgi',
+  '.pl',
+]
+
+module.exports = function (req, res, next) {
+  const url = (req.url || '').toLowerCase()
+  const pathname = url.split('?')[0]
+
+  // Verificar paths bloqueados
+  for (const blockedPath of BLOCKED_PATHS) {
+    if (pathname.startsWith(blockedPath.toLowerCase())) {
+      res.statusCode = 404
+      res.end('Not Found')
+      return
+    }
+  }
+
+  // Verificar extensiones bloqueadas
+  for (const ext of BLOCKED_EXTENSIONS) {
+    if (pathname.endsWith(ext)) {
+      res.statusCode = 404
+      res.end('Not Found')
+      return
+    }
+  }
+
+  next()
+}

--- a/static/meta.json
+++ b/static/meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "Komercia Store",
+  "version": "6.0.0",
+  "description": "Tienda Online - Komercia"
+}

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,14 @@
+User-agent: *
+Allow: /
+Disallow: /cart
+Disallow: /micompra
+Disallow: /wa/*/micompra
+Disallow: /_nuxt/
+Disallow: /api/
+
+# Block common bot paths
+Disallow: /wp-admin/
+Disallow: /wp-login.php
+Disallow: /administrator/
+Disallow: /.env
+Disallow: /config.php

--- a/store/index.js
+++ b/store/index.js
@@ -3,8 +3,8 @@ import axios from 'axios'
 import getCookie from '../utils/getCookie'
 import { normalizeCloudinaryPayload } from '@/utils/cloudinary'
 
-// Timeout para llamadas API en SSR (8 segundos)
-const API_TIMEOUT = 8000
+// Timeout para llamadas API en SSR (configurable via env, default 8 segundos)
+const API_TIMEOUT = parseInt(process.env.API_TIMEOUT) || 8000
 export const state = () => ({
   fullPathServer: '',
   template: '',

--- a/store/index.js
+++ b/store/index.js
@@ -2,6 +2,9 @@ export const strict = false
 import axios from 'axios'
 import getCookie from '../utils/getCookie'
 import { normalizeCloudinaryPayload } from '@/utils/cloudinary'
+
+// Timeout para llamadas API en SSR (8 segundos)
+const API_TIMEOUT = 8000
 export const state = () => ({
   fullPathServer: '',
   template: '',
@@ -397,6 +400,7 @@ export const actions = {
         headers: {
           KOMERCIA_PUBLIC_ROUTES_KEY: state.routerKey,
         },
+        timeout: API_TIMEOUT,
       })
       if (data) {
         commit('DATA', data)
@@ -409,7 +413,7 @@ export const actions = {
         commit('SET_DATA')
       }
     } catch (err) {
-      console.log('Data store', err?.response)
+      console.log('Data store', err?.message || err?.response)
     }
   },
   GET_DATA({ commit }) {
@@ -423,12 +427,13 @@ export const actions = {
         headers: {
           KOMERCIA_PUBLIC_ROUTES_KEY: state.routerKey,
         },
+        timeout: API_TIMEOUT,
       })
       if (data) {
         commit('SET_LOGO_STORE', data.data)
       }
     } catch (err) {
-      console.log('GET_LOGO_STORE', err?.response)
+      console.log('GET_LOGO_STORE', err?.message || err?.response)
     }
   },
 
@@ -499,13 +504,14 @@ export const actions = {
         headers: {
           KOMERCIA_PUBLIC_ROUTES_KEY: state.routerKey,
         },
+        timeout: API_TIMEOUT,
       })
       if (data) {
         commit('SET_CATEGORIES', data.data)
         return { success: true, data: data }
       }
     } catch (err) {
-      console.log('Data categories', err?.response)
+      console.log('Data categories', err?.message || err?.response)
     }
   },
   async GET_SUBCATEGORIES({ commit, state }, idTienda) {
@@ -516,13 +522,14 @@ export const actions = {
         headers: {
           KOMERCIA_PUBLIC_ROUTES_KEY: state.routerKey,
         },
+        timeout: API_TIMEOUT,
       })
       if (data) {
         commit('SET_SUBCATEGORIES', data.data)
         return { success: true, data: data }
       }
     } catch (err) {
-      console.log('Data subcategories', err?.response)
+      console.log('Data subcategories', err?.message || err?.response)
     }
   },
   async GET_GEOLOCALIZACION({ commit, state }, idTienda) {
@@ -621,6 +628,7 @@ export const actions = {
         headers: {
           KOMERCIA_PUBLIC_ROUTES_KEY: state.routerKey,
         },
+        timeout: API_TIMEOUT,
       })
       if (data) {
         commit(`SET_SETTINGS_BY_TEMPLATE`, {
@@ -629,7 +637,7 @@ export const actions = {
         })
       }
     } catch (err) {
-      console.log('Data setting Laravel', err?.response)
+      console.log('Data setting Laravel', err?.message || err?.response)
     }
   },
   async GET_SETTINGS_BY_TEMPLATE_NODE(
@@ -640,6 +648,7 @@ export const actions = {
       const { data } = await axios({
         method: 'GET',
         url: `${state.urlNodeSettings}/template${templateStore}?id=${idStore}`,
+        timeout: API_TIMEOUT,
       })
       if (data) {
         commit(`SET_SETTINGS_BY_TEMPLATE`, {
@@ -648,7 +657,7 @@ export const actions = {
         })
       }
     } catch (err) {
-      console.log('Data setting NODE', err?.response)
+      console.log('Data setting NODE', err?.message || err?.response)
     }
   },
   // async GET_SETTINGS_BY_TEMPLATE_AWS(
@@ -697,12 +706,13 @@ export const actions = {
         headers: {
           KOMERCIA_PUBLIC_ROUTES_KEY: state.routerKey,
         },
+        timeout: API_TIMEOUT,
       })
       if (data) {
         commit('SET_ANALITICS_TAGMANAGER', data.data)
       }
     } catch (err) {
-      console.log('Data integraciones', err?.response)
+      console.log('Data integraciones', err?.message || err?.response)
     }
   },
   async GET_DESCUENTOS({ state }) {
@@ -1285,7 +1295,8 @@ async function getIdData(state, req, commit) {
   } else if (getURL?.esSubdominio && getURL?.nombreTienda) {
     try {
       const response = await axios.get(
-        `${state.urlAWSsettings}/api/v1/templates/websites/template?criteria=${getURL.nombreTienda}`
+        `${state.urlAWSsettings}/api/v1/templates/websites/template?criteria=${getURL.nombreTienda}`,
+        { timeout: API_TIMEOUT }
       )
 
       id = response.data.data.id || response.data.data.storeId
@@ -1305,13 +1316,14 @@ async function getIdData(state, req, commit) {
       }
     } catch (err) {
       console.log(
-        `No se encontro la tienda ${getURL.nombreTienda} subdominio, ${err}`
+        `No se encontro la tienda ${getURL.nombreTienda} subdominio, ${err?.message || err}`
       )
     }
   } else if (getURL?.esDominio && getURL?.nombreTienda) {
     try {
       const response = await axios.get(
-        `${state.urlAWSsettings}/api/v1/templates/websites/template?criteria=${getURL?.nombreTienda}&isDomain=1`
+        `${state.urlAWSsettings}/api/v1/templates/websites/template?criteria=${getURL?.nombreTienda}&isDomain=1`,
+        { timeout: API_TIMEOUT }
       )
       id = response.data.data.id || response.data.data.storeId
       template =
@@ -1324,7 +1336,7 @@ async function getIdData(state, req, commit) {
       }
     } catch (err) {
       console.log(
-        `No se encontro la tienda ${getURL.nombreTienda} dominio, ${err}`
+        `No se encontro la tienda ${getURL.nombreTienda} dominio, ${err?.message || err}`
       )
     }
   }

--- a/utils/axiosRetry.js
+++ b/utils/axiosRetry.js
@@ -1,0 +1,104 @@
+import axios from 'axios'
+
+// Timeout por defecto para todas las llamadas API (8 segundos)
+const DEFAULT_TIMEOUT = 8000
+
+// Número máximo de reintentos para errores de red
+const MAX_RETRIES = 2
+
+// Delay entre reintentos (ms)
+const RETRY_DELAY = 500
+
+// Errores que merecen reintento
+const RETRYABLE_ERRORS = [
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'ECONNABORTED',
+  'ENOTFOUND',
+  'ENETUNREACH',
+  'EAI_AGAIN',
+]
+
+/**
+ * Verifica si un error es recuperable y merece reintento
+ */
+function isRetryableError(error) {
+  if (!error) return false
+
+  // Error de timeout de axios
+  if (error.code === 'ECONNABORTED') return true
+
+  // Errores de red
+  if (error.code && RETRYABLE_ERRORS.includes(error.code)) return true
+
+  // Error de respuesta 5xx del servidor (excepto 500 que puede ser intencional)
+  if (error.response && error.response.status >= 502 && error.response.status <= 504) {
+    return true
+  }
+
+  return false
+}
+
+/**
+ * Espera un tiempo determinado
+ */
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/**
+ * Realiza una petición HTTP con timeout y reintentos automáticos
+ * @param {Object} config - Configuración de axios
+ * @param {Object} options - Opciones adicionales
+ * @param {number} options.timeout - Timeout en ms (default: 8000)
+ * @param {number} options.retries - Número de reintentos (default: 2)
+ * @returns {Promise} - Respuesta de axios
+ */
+export async function axiosWithRetry(config, options = {}) {
+  const timeout = options.timeout || DEFAULT_TIMEOUT
+  const maxRetries = options.retries !== undefined ? options.retries : MAX_RETRIES
+
+  let lastError = null
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      const response = await axios({
+        ...config,
+        timeout,
+      })
+      return response
+    } catch (error) {
+      lastError = error
+
+      // Si no es un error recuperable, no reintentar
+      if (!isRetryableError(error)) {
+        throw error
+      }
+
+      // Si ya agotamos los reintentos, lanzar error
+      if (attempt >= maxRetries) {
+        throw error
+      }
+
+      // Esperar antes de reintentar (con backoff exponencial simple)
+      const delay = RETRY_DELAY * (attempt + 1)
+      await sleep(delay)
+    }
+  }
+
+  throw lastError
+}
+
+/**
+ * Crea una instancia de axios preconfigurada con timeout
+ */
+export function createAxiosInstance(baseConfig = {}) {
+  const instance = axios.create({
+    timeout: DEFAULT_TIMEOUT,
+    ...baseConfig,
+  })
+
+  return instance
+}
+
+export default axiosWithRetry

--- a/vercel.json
+++ b/vercel.json
@@ -5,9 +5,7 @@
       "src": "nuxt.config.js",
       "use": "@nuxtjs/vercel-builder",
       "config": {
-        "serverFiles": ["server-middleware/**"],
-        "memory": 1024,
-        "maxDuration": 30
+        "serverFiles": ["server-middleware/**"]
       }
     }
   ],
@@ -27,6 +25,24 @@
         {
           "key": "Cache-Control",
           "value": "public, max-age=86400, stale-while-revalidate=604800"
+        }
+      ]
+    },
+    {
+      "source": "/robots.txt",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=86400"
+        }
+      ]
+    },
+    {
+      "source": "/meta.json",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=3600"
         }
       ]
     },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improve SSR stability by enforcing API timeouts, blocking bot/scanner routes, and adding safe fallbacks for Hoko product templates. Also adds robots.txt/meta.json and caching headers to cut 404s and unnecessary SSR work.

- **Bug Fixes**
  - Added KoNoDisponibleHoko and a default mapping in productosHoko to prevent “render function not defined” errors for unmapped templates.

- **Refactors**
  - Enforced 8s API timeout on critical SSR requests (configurable via API_TIMEOUT) and improved error logging; added axiosRetry utility for future use.
  - Reduced bot load with new block-bots middleware and robots.txt; added meta.json and cache headers for robots.txt/meta.json in vercel.json.

<sup>Written for commit c5211deb018e213d87368aac256929d77eae7af4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

